### PR TITLE
feat: Add transferables helper for expose-side transfer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,30 @@ const result = await api("processBuffer", [buffer], {
 console.log(buffer.byteLength); // 0
 ```
 
+### Transfer from Handler
+
+```ts ignore
+import { transferables } from "jsr:@takker/endpoint-link";
+
+const handlers = {
+  getBuffer() {
+    const buf = new ArrayBuffer(1024);
+    // Mark the return value with transferable objects
+    return transferables(buf, [buf]);
+  },
+  getStream() {
+    const stream = new ReadableStream({ ... });
+    return transferables(stream, [stream]);
+  },
+  getPort() {
+    const mc = new MessageChannel();
+    return transferables(mc.port1, [mc.port1]);
+  },
+};
+
+using disposable = expose(endpoint, handlers);
+```
+
 ### Custom Timeout
 
 ```ts ignore

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,8 +1,8 @@
 {
   "exports": "./mod.ts",
   "imports": {
-    "@std/assert": "jsr:@std/assert@^1.0.18",
-    "@std/async": "jsr:@std/async@^1.1.1",
+    "@std/assert": "jsr:@std/assert@^1.0.19",
+    "@std/async": "jsr:@std/async@^1.4.0",
     "@takker/endpoint-link": "./mod.ts"
   },
   "license": "MIT",

--- a/deno.lock
+++ b/deno.lock
@@ -1,28 +1,35 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@std/assert@^1.0.18": "1.0.18",
-    "jsr:@std/async@^1.1.1": "1.1.1",
-    "jsr:@std/internal@^1.0.12": "1.0.12"
+    "jsr:@std/assert@^1.0.19": "1.0.19",
+    "jsr:@std/async@^1.4.0": "1.4.0",
+    "jsr:@std/data-structures@^1.1.0": "1.1.0",
+    "jsr:@std/internal@^1.0.12": "1.0.14"
   },
   "jsr": {
-    "@std/assert@1.0.18": {
-      "integrity": "270245e9c2c13b446286de475131dc688ca9abcd94fc5db41d43a219b34d1c78",
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
       "dependencies": [
         "jsr:@std/internal"
       ]
     },
-    "@std/async@1.1.1": {
-      "integrity": "8a79beb3378cc229ce65ba2c746cfd03e4855ddd891d1eb6b9e32128e0d5339c"
+    "@std/async@1.4.0": {
+      "integrity": "4d70b008634f571cff9b554090d628c76141c32613aae0ff283fd5fa23d0c379",
+      "dependencies": [
+        "jsr:@std/data-structures"
+      ]
     },
-    "@std/internal@1.0.12": {
-      "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
+    "@std/data-structures@1.1.0": {
+      "integrity": "c35ae4ad5d8e41a38573c2fe3e19b18ea2505f63cfea201edcb8720aca1f7f58"
+    },
+    "@std/internal@1.0.14": {
+      "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
     }
   },
   "workspace": {
     "dependencies": [
-      "jsr:@std/assert@^1.0.18",
-      "jsr:@std/async@^1.1.1"
+      "jsr:@std/assert@^1.0.19",
+      "jsr:@std/async@^1.4.0"
     ]
   }
 }

--- a/expose.ts
+++ b/expose.ts
@@ -12,6 +12,7 @@ import type {
   ExposeOptions,
   RemoteProcedureMap,
 } from "./types.ts";
+import { kTransferables } from "./types.ts";
 import { signalReady } from "./signal_ready.ts";
 import { on, onMessageError } from "./on.ts";
 
@@ -52,9 +53,12 @@ export const expose = <H extends RemoteProcedureMap>(
       try {
         // deno-lint-ignore no-explicit-any
         const res = await (h as any)(...args, ac.signal);
+        const transferList = (res as any)?.[kTransferables] as
+          | Transferable[]
+          | undefined;
         endpoint.postMessage(
           { id, kind: "result", result: res } as ResultMsg,
-          [],
+          transferList ?? [],
         );
       } catch (e) {
         if (ac.signal.aborted) {

--- a/expose.ts
+++ b/expose.ts
@@ -53,7 +53,9 @@ export const expose = <H extends RemoteProcedureMap>(
       try {
         // deno-lint-ignore no-explicit-any
         const res = await (h as any)(...args, ac.signal);
-        const transferList = (res as any)?.[kTransferables] as
+        const transferList = (res as Record<symbol, unknown>)?.[
+          kTransferables
+        ] as
           | Transferable[]
           | undefined;
         endpoint.postMessage(

--- a/expose_test.ts
+++ b/expose_test.ts
@@ -1,10 +1,14 @@
 import { expose } from "./expose.ts";
 import { wrap } from "./wrap.ts";
 import { delay } from "@std/async/delay";
-import { assertRejects } from "@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
 import { memoryPair } from "./test_utils.ts";
+import { transferables } from "./types.ts";
 
-Deno.test("expose()", async (t) => {
+Deno.test({
+  name: "expose()",
+  sanitizeResources: false,
+  async fn(t) {
   await t.step("handles messageerror silently", () => {
     using pair = memoryPair();
     const { port1: a } = pair;
@@ -108,4 +112,420 @@ Deno.test("expose()", async (t) => {
 
     // After dispose, should not respond to new calls (listeners removed)
   });
+
+  await t.step(
+    "returns transferable ArrayBuffer from handler",
+    async () => {
+      using pair = memoryPair();
+      const { port1: a, port2: b } = pair;
+      const handlers = {
+        getBuffer() {
+          const buf = new Uint8Array([1, 2, 3]).buffer;
+          return transferables(buf, [buf]);
+        },
+      };
+
+      using _exposer = expose(a, handlers);
+      const api = await wrap<typeof handlers>(b);
+
+      const result = await api("getBuffer", []);
+      assertEquals(result instanceof ArrayBuffer, true);
+      assertEquals(new Uint8Array(result as ArrayBuffer), new Uint8Array([1, 2, 3]));
+    },
+  );
+
+  await t.step(
+    "returns transferable ReadableStream from handler",
+    async () => {
+      using pair = memoryPair();
+      const { port1: a, port2: b } = pair;
+      const handlers = {
+        getStream() {
+          const stream = new ReadableStream({
+            start(controller) {
+              controller.enqueue(new Uint8Array([4, 5, 6]));
+              controller.close();
+            },
+          });
+          return transferables(stream, [stream]);
+        },
+      };
+
+      using _exposer = expose(a, handlers);
+      const api = await wrap<typeof handlers>(b);
+
+      const result = await api("getStream", []);
+      assertEquals(result instanceof ReadableStream, true);
+      const reader = (result as ReadableStream<Uint8Array>).getReader();
+      const { value, done } = await reader.read();
+      assertEquals(done, false);
+      assertEquals(value, new Uint8Array([4, 5, 6]));
+      await reader.cancel();
+    },
+  );
+
+  await t.step(
+    "returns transferable ReadableStream - push multiple chunks",
+    async () => {
+      using pair = memoryPair();
+      const { port1: a, port2: b } = pair;
+      const handlers = {
+        getStream() {
+          const stream = new ReadableStream({
+            start(controller) {
+              controller.enqueue(new Uint8Array([1, 2, 3]));
+              controller.enqueue(new Uint8Array([4, 5, 6]));
+              controller.enqueue(new Uint8Array([7, 8, 9]));
+              controller.close();
+            },
+          });
+          return transferables(stream, [stream]);
+        },
+      };
+
+      using _exposer = expose(a, handlers);
+      const api = await wrap<typeof handlers>(b);
+
+      const result = await api("getStream", []);
+      const reader = (result as ReadableStream<Uint8Array>).getReader();
+
+      const values: Uint8Array[] = [];
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        values.push(value);
+      }
+
+      assertEquals(values.length, 3);
+      assertEquals(values[0], new Uint8Array([1, 2, 3]));
+      assertEquals(values[1], new Uint8Array([4, 5, 6]));
+      assertEquals(values[2], new Uint8Array([7, 8, 9]));
+      reader.releaseLock();
+    },
+  );
+
+  await t.step(
+    "returns transferable ReadableStream - pull based",
+    async () => {
+      using pair = memoryPair();
+      const { port1: a, port2: b } = pair;
+      const handlers = {
+        getStream() {
+          let count = 0;
+          const stream = new ReadableStream({
+            pull(controller) {
+              count++;
+              controller.enqueue(new Uint8Array([count]));
+              if (count >= 3) {
+                controller.close();
+              }
+            },
+          });
+          return transferables(stream, [stream]);
+        },
+      };
+
+      using _exposer = expose(a, handlers);
+      const api = await wrap<typeof handlers>(b);
+
+      const result = await api("getStream", []);
+      const reader = (result as ReadableStream<Uint8Array>).getReader();
+
+      const values: Uint8Array[] = [];
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        values.push(value);
+      }
+
+      assertEquals(values.length, 3);
+      assertEquals(values[0], new Uint8Array([1]));
+      assertEquals(values[1], new Uint8Array([2]));
+      assertEquals(values[2], new Uint8Array([3]));
+      reader.releaseLock();
+    },
+  );
+
+  await t.step(
+    "returns transferable ReadableStream - push and pull hybrid",
+    async () => {
+      using pair = memoryPair();
+      const { port1: a, port2: b } = pair;
+      const handlers = {
+        getStream() {
+          let pulled = false;
+          const stream = new ReadableStream({
+            start(controller) {
+              controller.enqueue(new Uint8Array([1]));
+            },
+            pull(controller) {
+              if (!pulled) {
+                pulled = true;
+                controller.enqueue(new Uint8Array([2]));
+                controller.enqueue(new Uint8Array([3]));
+                controller.close();
+              }
+            },
+          });
+          return transferables(stream, [stream]);
+        },
+      };
+
+      using _exposer = expose(a, handlers);
+      const api = await wrap<typeof handlers>(b);
+
+      const result = await api("getStream", []);
+      const reader = (result as ReadableStream<Uint8Array>).getReader();
+
+      const values: Uint8Array[] = [];
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        values.push(value);
+      }
+
+      assertEquals(values.length, 3);
+      assertEquals(values[0], new Uint8Array([1]));
+      assertEquals(values[1], new Uint8Array([2]));
+      assertEquals(values[2], new Uint8Array([3]));
+      reader.releaseLock();
+    },
+  );
+
+  await t.step(
+    "returns transferable ReadableStream - backpressure",
+    async () => {
+      using pair = memoryPair();
+      const { port1: a, port2: b } = pair;
+      const handlers = {
+        getStream() {
+          let count = 0;
+          const stream = new ReadableStream({
+            highWaterMark: 1,
+            pull(controller) {
+              count++;
+              return new Promise<void>((resolve) => {
+                setTimeout(() => {
+                  controller.enqueue(new Uint8Array([count]));
+                  if (count >= 3) {
+                    controller.close();
+                  }
+                  resolve();
+                }, 5);
+              });
+            },
+          });
+          return transferables(stream, [stream]);
+        },
+      };
+
+      using _exposer = expose(a, handlers);
+      const api = await wrap<typeof handlers>(b);
+
+      const result = await api("getStream", []);
+      const reader = (result as ReadableStream<Uint8Array>).getReader();
+
+      const values: Uint8Array[] = [];
+      for (let i = 0; i < 3; i++) {
+        const { value, done } = await reader.read();
+        assertEquals(done, false);
+        values.push(value);
+        await delay(10);
+      }
+
+      const { done } = await reader.read();
+      assertEquals(done, true);
+      assertEquals(values.length, 3);
+      assertEquals(values[0], new Uint8Array([1]));
+      assertEquals(values[1], new Uint8Array([2]));
+      assertEquals(values[2], new Uint8Array([3]));
+      reader.releaseLock();
+    },
+  );
+
+  await t.step(
+    "returns transferable ReadableStream - cancel mid stream",
+    async () => {
+      using pair = memoryPair();
+      const { port1: a, port2: b } = pair;
+      let cancelReason: string | undefined;
+      const handlers = {
+        getStream() {
+          const stream = new ReadableStream({
+            start(controller) {
+              controller.enqueue(new Uint8Array([1, 2, 3]));
+              controller.enqueue(new Uint8Array([4, 5, 6]));
+            },
+            cancel(reason) {
+              cancelReason = reason as string;
+            },
+          });
+          return transferables(stream, [stream]);
+        },
+      };
+
+      using _exposer = expose(a, handlers);
+      const api = await wrap<typeof handlers>(b);
+
+      const result = await api("getStream", []);
+      const reader = (result as ReadableStream<Uint8Array>).getReader();
+
+      const { value, done } = await reader.read();
+      assertEquals(done, false);
+      assertEquals(value, new Uint8Array([1, 2, 3]));
+
+      await reader.cancel("user cancelled");
+
+      // Allow time for cancel to propagate back
+      await delay(10);
+      assertEquals(cancelReason, "user cancelled");
+      reader.releaseLock();
+    },
+  );
+
+  await t.step(
+    "returns transferable ReadableStream - error propagation",
+    async () => {
+      using pair = memoryPair();
+      const { port1: a, port2: b } = pair;
+      const handlers = {
+        getStream() {
+          const stream = new ReadableStream({
+            start(controller) {
+              controller.error(new Error("stream broken"));
+            },
+          });
+          return transferables(stream, [stream]);
+        },
+      };
+
+      using _exposer = expose(a, handlers);
+      const api = await wrap<typeof handlers>(b);
+
+      const result = await api("getStream", []);
+      const reader = (result as ReadableStream<Uint8Array>).getReader();
+
+      await assertRejects(
+        () => reader.read(),
+        Error,
+        "stream broken",
+      );
+      reader.releaseLock();
+    },
+  );
+
+  await t.step(
+    "returns transferable ReadableStream - empty stream",
+    async () => {
+      using pair = memoryPair();
+      const { port1: a, port2: b } = pair;
+      const handlers = {
+        getStream() {
+          const stream = new ReadableStream({
+            start(controller) {
+              controller.close();
+            },
+          });
+          return transferables(stream, [stream]);
+        },
+      };
+
+      using _exposer = expose(a, handlers);
+      const api = await wrap<typeof handlers>(b);
+
+      const result = await api("getStream", []);
+      const reader = (result as ReadableStream<Uint8Array>).getReader();
+
+      const { done } = await reader.read();
+      assertEquals(done, true);
+      reader.releaseLock();
+    },
+  );
+
+  await t.step(
+    "returns transferable ReadableStream - large data",
+    async () => {
+      using pair = memoryPair();
+      const { port1: a, port2: b } = pair;
+      const handlers = {
+        getStream() {
+          const data = new Uint8Array(1024 * 1024); // 1MB
+          for (let i = 0; i < data.length; i++) {
+            data[i] = i % 256;
+          }
+          const stream = new ReadableStream({
+            start(controller) {
+              controller.enqueue(data);
+              controller.close();
+            },
+          });
+          return transferables(stream, [stream]);
+        },
+      };
+
+      using _exposer = expose(a, handlers);
+      const api = await wrap<typeof handlers>(b);
+
+      const result = await api("getStream", []);
+      const reader = (result as ReadableStream<Uint8Array>).getReader();
+
+      const { value, done } = await reader.read();
+      assertEquals(done, false);
+      assertEquals(value!.length, 1024 * 1024);
+
+      assertEquals(value![0], 0);
+      assertEquals(value![1023], 1023 % 256);
+      assertEquals(value![1024 * 1024 - 1], (1024 * 1024 - 1) % 256);
+
+      const { done: done2 } = await reader.read();
+      assertEquals(done2, true);
+      reader.releaseLock();
+    },
+  );
+
+  await t.step(
+    "returns transferable MessagePort from handler",
+    async () => {
+      using pair = memoryPair();
+      const { port1: a, port2: b } = pair;
+
+      // Create MessageChannel in test scope so we can clean up port2
+      const mc = new MessageChannel();
+      mc.port2.addEventListener("message", (ev) => {
+        mc.port2.postMessage(`echo: ${ev.data}`);
+      });
+      mc.port2.start();
+
+      const handlers = {
+        getPort() {
+          return transferables(mc.port1, [mc.port1]);
+        },
+      };
+
+      using _exposer = expose(a, handlers);
+      const api = await wrap<typeof handlers>(b);
+
+      const result = await api("getPort", []);
+      assertEquals(result instanceof MessagePort, true);
+
+      // Verify the port is actually usable after transfer
+      const port = result as MessagePort;
+      port.start();
+
+      const messagePromise = new Promise<string>((resolve) => {
+        port.addEventListener("message", (ev) => {
+          resolve(ev.data as string);
+        });
+      });
+
+      port.postMessage("hello from transferred port");
+      const received = await messagePromise;
+      assertEquals(received, "echo: hello from transferred port");
+
+      // Cleanup transferred port and the original channel's port2
+      port.close();
+      mc.port2.close();
+    },
+  );
+  },
 });

--- a/expose_test.ts
+++ b/expose_test.ts
@@ -9,523 +9,528 @@ Deno.test({
   name: "expose()",
   sanitizeResources: false,
   async fn(t) {
-  await t.step("handles messageerror silently", () => {
-    using pair = memoryPair();
-    const { port1: a } = pair;
-    const handlers = {
-      test() {
-        return "works";
-      },
-    };
+    await t.step("handles messageerror silently", () => {
+      using pair = memoryPair();
+      const { port1: a } = pair;
+      const handlers = {
+        test() {
+          return "works";
+        },
+      };
 
-    // Expose handlers
-    using _exposer = expose(a, handlers);
+      // Expose handlers
+      using _exposer = expose(a, handlers);
 
-    // Just make sure expose sets up the messageerror listener
-    // (No way to trigger real messageerror without unserializable data)
-    // This test ensures the listener is attached without crashing
-  });
+      // Just make sure expose sets up the messageerror listener
+      // (No way to trigger real messageerror without unserializable data)
+      // This test ensures the listener is attached without crashing
+    });
 
-  await t.step("handler throws and sends error result", async () => {
-    using pair = memoryPair();
-    const { port1: a, port2: b } = pair;
-    const handlers = {
-      throwError() {
-        throw new Error("handler error");
-      },
-    };
-
-    using _exposer = expose(a, handlers);
-    const api = await wrap<typeof handlers>(b);
-
-    await assertRejects(
-      () => api("throwError", []),
-      Error,
-      "handler error",
-    );
-  });
-
-  await t.step("handler throws null and sends unknown error", async () => {
-    using pair = memoryPair();
-    const { port1: a, port2: b } = pair;
-    const handlers = {
-      throwNull() {
-        throw null;
-      },
-    };
-
-    using _exposer = expose(a, handlers);
-    const api = await wrap<typeof handlers>(b);
-
-    await assertRejects(
-      () => api("throwNull", []),
-      Error,
-      "unknown",
-    );
-  });
-
-  await t.step(
-    "sends aborted error when handler is cancelled",
-    async () => {
+    await t.step("handler throws and sends error result", async () => {
       using pair = memoryPair();
       const { port1: a, port2: b } = pair;
       const handlers = {
-        longTask() {
-          return new Promise(() => {}); // Never resolves
+        throwError() {
+          throw new Error("handler error");
         },
       };
 
       using _exposer = expose(a, handlers);
       const api = await wrap<typeof handlers>(b);
-
-      const controller = new AbortController();
-      const callPromise = api("longTask", [], { signal: controller.signal });
-
-      // Wait for the call to be sent and registered on expose side
-      await delay(10);
-
-      // Send cancel message
-      controller.abort();
 
       await assertRejects(
-        () => callPromise,
+        () => api("throwError", []),
         Error,
-        "aborted",
+        "handler error",
       );
-    },
-  );
+    });
 
-  await t.step("dispose removes all listeners", () => {
-    using pair = memoryPair();
-    const { port1: a } = pair;
-    const handlers = {
-      test() {
-        return "works";
+    await t.step("handler throws null and sends unknown error", async () => {
+      using pair = memoryPair();
+      const { port1: a, port2: b } = pair;
+      const handlers = {
+        throwNull() {
+          throw null;
+        },
+      };
+
+      using _exposer = expose(a, handlers);
+      const api = await wrap<typeof handlers>(b);
+
+      await assertRejects(
+        () => api("throwNull", []),
+        Error,
+        "unknown",
+      );
+    });
+
+    await t.step(
+      "sends aborted error when handler is cancelled",
+      async () => {
+        using pair = memoryPair();
+        const { port1: a, port2: b } = pair;
+        const handlers = {
+          longTask() {
+            return new Promise(() => {}); // Never resolves
+          },
+        };
+
+        using _exposer = expose(a, handlers);
+        const api = await wrap<typeof handlers>(b);
+
+        const controller = new AbortController();
+        const callPromise = api("longTask", [], { signal: controller.signal });
+
+        // Wait for the call to be sent and registered on expose side
+        await delay(10);
+
+        // Send cancel message
+        controller.abort();
+
+        await assertRejects(
+          () => callPromise,
+          Error,
+          "aborted",
+        );
       },
-    };
+    );
 
-    // Use the disposer
-    const disposer = expose(a, handlers);
-
-    // Dispose immediately
-    disposer[Symbol.dispose]();
-
-    // After dispose, should not respond to new calls (listeners removed)
-  });
-
-  await t.step(
-    "returns transferable ArrayBuffer from handler",
-    async () => {
+    await t.step("dispose removes all listeners", () => {
       using pair = memoryPair();
-      const { port1: a, port2: b } = pair;
+      const { port1: a } = pair;
       const handlers = {
-        getBuffer() {
-          const buf = new Uint8Array([1, 2, 3]).buffer;
-          return transferables(buf, [buf]);
+        test() {
+          return "works";
         },
       };
 
-      using _exposer = expose(a, handlers);
-      const api = await wrap<typeof handlers>(b);
+      // Use the disposer
+      const disposer = expose(a, handlers);
 
-      const result = await api("getBuffer", []);
-      assertEquals(result instanceof ArrayBuffer, true);
-      assertEquals(new Uint8Array(result as ArrayBuffer), new Uint8Array([1, 2, 3]));
-    },
-  );
+      // Dispose immediately
+      disposer[Symbol.dispose]();
 
-  await t.step(
-    "returns transferable ReadableStream from handler",
-    async () => {
-      using pair = memoryPair();
-      const { port1: a, port2: b } = pair;
-      const handlers = {
-        getStream() {
-          const stream = new ReadableStream({
-            start(controller) {
-              controller.enqueue(new Uint8Array([4, 5, 6]));
-              controller.close();
-            },
-          });
-          return transferables(stream, [stream]);
-        },
-      };
+      // After dispose, should not respond to new calls (listeners removed)
+    });
 
-      using _exposer = expose(a, handlers);
-      const api = await wrap<typeof handlers>(b);
+    await t.step(
+      "returns transferable ArrayBuffer from handler",
+      async () => {
+        using pair = memoryPair();
+        const { port1: a, port2: b } = pair;
+        const handlers = {
+          getBuffer() {
+            const buf = new Uint8Array([1, 2, 3]).buffer;
+            return transferables(buf, [buf]);
+          },
+        };
 
-      const result = await api("getStream", []);
-      assertEquals(result instanceof ReadableStream, true);
-      const reader = (result as ReadableStream<Uint8Array>).getReader();
-      const { value, done } = await reader.read();
-      assertEquals(done, false);
-      assertEquals(value, new Uint8Array([4, 5, 6]));
-      await reader.cancel();
-    },
-  );
+        using _exposer = expose(a, handlers);
+        const api = await wrap<typeof handlers>(b);
 
-  await t.step(
-    "returns transferable ReadableStream - push multiple chunks",
-    async () => {
-      using pair = memoryPair();
-      const { port1: a, port2: b } = pair;
-      const handlers = {
-        getStream() {
-          const stream = new ReadableStream({
-            start(controller) {
-              controller.enqueue(new Uint8Array([1, 2, 3]));
-              controller.enqueue(new Uint8Array([4, 5, 6]));
-              controller.enqueue(new Uint8Array([7, 8, 9]));
-              controller.close();
-            },
-          });
-          return transferables(stream, [stream]);
-        },
-      };
+        const result = await api("getBuffer", []);
+        assertEquals(result instanceof ArrayBuffer, true);
+        assertEquals(
+          new Uint8Array(result as ArrayBuffer),
+          new Uint8Array([1, 2, 3]),
+        );
+      },
+    );
 
-      using _exposer = expose(a, handlers);
-      const api = await wrap<typeof handlers>(b);
-
-      const result = await api("getStream", []);
-      const reader = (result as ReadableStream<Uint8Array>).getReader();
-
-      const values: Uint8Array[] = [];
-      while (true) {
-        const { value, done } = await reader.read();
-        if (done) break;
-        values.push(value);
-      }
-
-      assertEquals(values.length, 3);
-      assertEquals(values[0], new Uint8Array([1, 2, 3]));
-      assertEquals(values[1], new Uint8Array([4, 5, 6]));
-      assertEquals(values[2], new Uint8Array([7, 8, 9]));
-      reader.releaseLock();
-    },
-  );
-
-  await t.step(
-    "returns transferable ReadableStream - pull based",
-    async () => {
-      using pair = memoryPair();
-      const { port1: a, port2: b } = pair;
-      const handlers = {
-        getStream() {
-          let count = 0;
-          const stream = new ReadableStream({
-            pull(controller) {
-              count++;
-              controller.enqueue(new Uint8Array([count]));
-              if (count >= 3) {
+    await t.step(
+      "returns transferable ReadableStream from handler",
+      async () => {
+        using pair = memoryPair();
+        const { port1: a, port2: b } = pair;
+        const handlers = {
+          getStream() {
+            const stream = new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(new Uint8Array([4, 5, 6]));
                 controller.close();
-              }
-            },
-          });
-          return transferables(stream, [stream]);
-        },
-      };
+              },
+            });
+            return transferables(stream, [stream]);
+          },
+        };
 
-      using _exposer = expose(a, handlers);
-      const api = await wrap<typeof handlers>(b);
+        using _exposer = expose(a, handlers);
+        const api = await wrap<typeof handlers>(b);
 
-      const result = await api("getStream", []);
-      const reader = (result as ReadableStream<Uint8Array>).getReader();
-
-      const values: Uint8Array[] = [];
-      while (true) {
-        const { value, done } = await reader.read();
-        if (done) break;
-        values.push(value);
-      }
-
-      assertEquals(values.length, 3);
-      assertEquals(values[0], new Uint8Array([1]));
-      assertEquals(values[1], new Uint8Array([2]));
-      assertEquals(values[2], new Uint8Array([3]));
-      reader.releaseLock();
-    },
-  );
-
-  await t.step(
-    "returns transferable ReadableStream - push and pull hybrid",
-    async () => {
-      using pair = memoryPair();
-      const { port1: a, port2: b } = pair;
-      const handlers = {
-        getStream() {
-          let pulled = false;
-          const stream = new ReadableStream({
-            start(controller) {
-              controller.enqueue(new Uint8Array([1]));
-            },
-            pull(controller) {
-              if (!pulled) {
-                pulled = true;
-                controller.enqueue(new Uint8Array([2]));
-                controller.enqueue(new Uint8Array([3]));
-                controller.close();
-              }
-            },
-          });
-          return transferables(stream, [stream]);
-        },
-      };
-
-      using _exposer = expose(a, handlers);
-      const api = await wrap<typeof handlers>(b);
-
-      const result = await api("getStream", []);
-      const reader = (result as ReadableStream<Uint8Array>).getReader();
-
-      const values: Uint8Array[] = [];
-      while (true) {
-        const { value, done } = await reader.read();
-        if (done) break;
-        values.push(value);
-      }
-
-      assertEquals(values.length, 3);
-      assertEquals(values[0], new Uint8Array([1]));
-      assertEquals(values[1], new Uint8Array([2]));
-      assertEquals(values[2], new Uint8Array([3]));
-      reader.releaseLock();
-    },
-  );
-
-  await t.step(
-    "returns transferable ReadableStream - backpressure",
-    async () => {
-      using pair = memoryPair();
-      const { port1: a, port2: b } = pair;
-      const handlers = {
-        getStream() {
-          let count = 0;
-          const stream = new ReadableStream({
-            highWaterMark: 1,
-            pull(controller) {
-              count++;
-              return new Promise<void>((resolve) => {
-                setTimeout(() => {
-                  controller.enqueue(new Uint8Array([count]));
-                  if (count >= 3) {
-                    controller.close();
-                  }
-                  resolve();
-                }, 5);
-              });
-            },
-          });
-          return transferables(stream, [stream]);
-        },
-      };
-
-      using _exposer = expose(a, handlers);
-      const api = await wrap<typeof handlers>(b);
-
-      const result = await api("getStream", []);
-      const reader = (result as ReadableStream<Uint8Array>).getReader();
-
-      const values: Uint8Array[] = [];
-      for (let i = 0; i < 3; i++) {
+        const result = await api("getStream", []);
+        assertEquals(result instanceof ReadableStream, true);
+        const reader = result.getReader();
         const { value, done } = await reader.read();
         assertEquals(done, false);
-        values.push(value);
+        assertEquals(value, new Uint8Array([4, 5, 6]));
+        await reader.cancel();
+      },
+    );
+
+    await t.step(
+      "returns transferable ReadableStream - push multiple chunks",
+      async () => {
+        using pair = memoryPair();
+        const { port1: a, port2: b } = pair;
+        const handlers = {
+          getStream() {
+            const stream = new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(new Uint8Array([1, 2, 3]));
+                controller.enqueue(new Uint8Array([4, 5, 6]));
+                controller.enqueue(new Uint8Array([7, 8, 9]));
+                controller.close();
+              },
+            });
+            return transferables(stream, [stream]);
+          },
+        };
+
+        using _exposer = expose(a, handlers);
+        const api = await wrap<typeof handlers>(b);
+
+        const result = await api("getStream", []);
+        const reader = result.getReader();
+
+        const values: Uint8Array[] = [];
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          values.push(value);
+        }
+
+        assertEquals(values.length, 3);
+        assertEquals(values[0], new Uint8Array([1, 2, 3]));
+        assertEquals(values[1], new Uint8Array([4, 5, 6]));
+        assertEquals(values[2], new Uint8Array([7, 8, 9]));
+        reader.releaseLock();
+      },
+    );
+
+    await t.step(
+      "returns transferable ReadableStream - pull based",
+      async () => {
+        using pair = memoryPair();
+        const { port1: a, port2: b } = pair;
+        const handlers = {
+          getStream() {
+            let count = 0;
+            const stream = new ReadableStream<Uint8Array>({
+              pull(controller) {
+                count++;
+                controller.enqueue(new Uint8Array([count]));
+                if (count >= 3) {
+                  controller.close();
+                }
+              },
+            });
+            return transferables(stream, [stream]);
+          },
+        };
+
+        using _exposer = expose(a, handlers);
+        const api = await wrap<typeof handlers>(b);
+
+        const result = await api("getStream", []);
+        const reader = result.getReader();
+
+        const values: Uint8Array[] = [];
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          values.push(value);
+        }
+
+        assertEquals(values.length, 3);
+        assertEquals(values[0], new Uint8Array([1]));
+        assertEquals(values[1], new Uint8Array([2]));
+        assertEquals(values[2], new Uint8Array([3]));
+        reader.releaseLock();
+      },
+    );
+
+    await t.step(
+      "returns transferable ReadableStream - push and pull hybrid",
+      async () => {
+        using pair = memoryPair();
+        const { port1: a, port2: b } = pair;
+        const handlers = {
+          getStream() {
+            let pulled = false;
+            const stream = new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(new Uint8Array([1]));
+              },
+              pull(controller) {
+                if (!pulled) {
+                  pulled = true;
+                  controller.enqueue(new Uint8Array([2]));
+                  controller.enqueue(new Uint8Array([3]));
+                  controller.close();
+                }
+              },
+            });
+            return transferables(stream, [stream]);
+          },
+        };
+
+        using _exposer = expose(a, handlers);
+        const api = await wrap<typeof handlers>(b);
+
+        const result = await api("getStream", []);
+        const reader = result.getReader();
+
+        const values: Uint8Array[] = [];
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          values.push(value);
+        }
+
+        assertEquals(values.length, 3);
+        assertEquals(values[0], new Uint8Array([1]));
+        assertEquals(values[1], new Uint8Array([2]));
+        assertEquals(values[2], new Uint8Array([3]));
+        reader.releaseLock();
+      },
+    );
+
+    await t.step(
+      "returns transferable ReadableStream - backpressure",
+      async () => {
+        using pair = memoryPair();
+        const { port1: a, port2: b } = pair;
+        const handlers = {
+          getStream() {
+            let count = 0;
+            const stream = new ReadableStream<Uint8Array>(
+              {
+                pull(controller) {
+                  count++;
+                  return new Promise<void>((resolve) => {
+                    setTimeout(() => {
+                      controller.enqueue(new Uint8Array([count]));
+                      if (count >= 3) {
+                        controller.close();
+                      }
+                      resolve();
+                    }, 5);
+                  });
+                },
+              },
+              { highWaterMark: 1 },
+            );
+            return transferables(stream, [stream]);
+          },
+        };
+
+        using _exposer = expose(a, handlers);
+        const api = await wrap<typeof handlers>(b);
+
+        const result = await api("getStream", []);
+        const reader = result.getReader();
+
+        const values: Uint8Array[] = [];
+        for (let i = 0; i < 3; i++) {
+          const { value, done } = await reader.read();
+          assertEquals(done, false);
+          values.push(value!);
+          await delay(10);
+        }
+
+        const { done } = await reader.read();
+        assertEquals(done, true);
+        assertEquals(values.length, 3);
+        assertEquals(values[0], new Uint8Array([1]));
+        assertEquals(values[1], new Uint8Array([2]));
+        assertEquals(values[2], new Uint8Array([3]));
+        reader.releaseLock();
+      },
+    );
+
+    await t.step(
+      "returns transferable ReadableStream - cancel mid stream",
+      async () => {
+        using pair = memoryPair();
+        const { port1: a, port2: b } = pair;
+        let cancelReason: string | undefined;
+        const handlers = {
+          getStream() {
+            const stream = new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(new Uint8Array([1, 2, 3]));
+                controller.enqueue(new Uint8Array([4, 5, 6]));
+              },
+              cancel(reason) {
+                cancelReason = reason as string;
+              },
+            });
+            return transferables(stream, [stream]);
+          },
+        };
+
+        using _exposer = expose(a, handlers);
+        const api = await wrap<typeof handlers>(b);
+
+        const result = await api("getStream", []);
+        const reader = result.getReader();
+
+        const { value, done } = await reader.read();
+        assertEquals(done, false);
+        assertEquals(value, new Uint8Array([1, 2, 3]));
+
+        await reader.cancel("user cancelled");
+
+        // Allow time for cancel to propagate back
         await delay(10);
-      }
+        assertEquals(cancelReason, "user cancelled");
+        reader.releaseLock();
+      },
+    );
 
-      const { done } = await reader.read();
-      assertEquals(done, true);
-      assertEquals(values.length, 3);
-      assertEquals(values[0], new Uint8Array([1]));
-      assertEquals(values[1], new Uint8Array([2]));
-      assertEquals(values[2], new Uint8Array([3]));
-      reader.releaseLock();
-    },
-  );
+    await t.step(
+      "returns transferable ReadableStream - error propagation",
+      async () => {
+        using pair = memoryPair();
+        const { port1: a, port2: b } = pair;
+        const handlers = {
+          getStream() {
+            const stream = new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.error(new Error("stream broken"));
+              },
+            });
+            return transferables(stream, [stream]);
+          },
+        };
 
-  await t.step(
-    "returns transferable ReadableStream - cancel mid stream",
-    async () => {
-      using pair = memoryPair();
-      const { port1: a, port2: b } = pair;
-      let cancelReason: string | undefined;
-      const handlers = {
-        getStream() {
-          const stream = new ReadableStream({
-            start(controller) {
-              controller.enqueue(new Uint8Array([1, 2, 3]));
-              controller.enqueue(new Uint8Array([4, 5, 6]));
-            },
-            cancel(reason) {
-              cancelReason = reason as string;
-            },
-          });
-          return transferables(stream, [stream]);
-        },
-      };
+        using _exposer = expose(a, handlers);
+        const api = await wrap<typeof handlers>(b);
 
-      using _exposer = expose(a, handlers);
-      const api = await wrap<typeof handlers>(b);
+        const result = await api("getStream", []);
+        const reader = result.getReader();
 
-      const result = await api("getStream", []);
-      const reader = (result as ReadableStream<Uint8Array>).getReader();
+        await assertRejects(
+          () => reader.read(),
+          Error,
+          "stream broken",
+        );
+        reader.releaseLock();
+      },
+    );
 
-      const { value, done } = await reader.read();
-      assertEquals(done, false);
-      assertEquals(value, new Uint8Array([1, 2, 3]));
+    await t.step(
+      "returns transferable ReadableStream - empty stream",
+      async () => {
+        using pair = memoryPair();
+        const { port1: a, port2: b } = pair;
+        const handlers = {
+          getStream() {
+            const stream = new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.close();
+              },
+            });
+            return transferables(stream, [stream]);
+          },
+        };
 
-      await reader.cancel("user cancelled");
+        using _exposer = expose(a, handlers);
+        const api = await wrap<typeof handlers>(b);
 
-      // Allow time for cancel to propagate back
-      await delay(10);
-      assertEquals(cancelReason, "user cancelled");
-      reader.releaseLock();
-    },
-  );
+        const result = await api("getStream", []);
+        const reader = result.getReader();
 
-  await t.step(
-    "returns transferable ReadableStream - error propagation",
-    async () => {
-      using pair = memoryPair();
-      const { port1: a, port2: b } = pair;
-      const handlers = {
-        getStream() {
-          const stream = new ReadableStream({
-            start(controller) {
-              controller.error(new Error("stream broken"));
-            },
-          });
-          return transferables(stream, [stream]);
-        },
-      };
+        const { done } = await reader.read();
+        assertEquals(done, true);
+        reader.releaseLock();
+      },
+    );
 
-      using _exposer = expose(a, handlers);
-      const api = await wrap<typeof handlers>(b);
+    await t.step(
+      "returns transferable ReadableStream - large data",
+      async () => {
+        using pair = memoryPair();
+        const { port1: a, port2: b } = pair;
+        const handlers = {
+          getStream() {
+            const data = new Uint8Array(1024 * 1024); // 1MB
+            for (let i = 0; i < data.length; i++) {
+              data[i] = i % 256;
+            }
+            const stream = new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(data);
+                controller.close();
+              },
+            });
+            return transferables(stream, [stream]);
+          },
+        };
 
-      const result = await api("getStream", []);
-      const reader = (result as ReadableStream<Uint8Array>).getReader();
+        using _exposer = expose(a, handlers);
+        const api = await wrap<typeof handlers>(b);
 
-      await assertRejects(
-        () => reader.read(),
-        Error,
-        "stream broken",
-      );
-      reader.releaseLock();
-    },
-  );
+        const result = await api("getStream", []);
+        const reader = result.getReader();
 
-  await t.step(
-    "returns transferable ReadableStream - empty stream",
-    async () => {
-      using pair = memoryPair();
-      const { port1: a, port2: b } = pair;
-      const handlers = {
-        getStream() {
-          const stream = new ReadableStream({
-            start(controller) {
-              controller.close();
-            },
-          });
-          return transferables(stream, [stream]);
-        },
-      };
+        const { value, done } = await reader.read();
+        assertEquals(done, false);
+        assertEquals(value!.length, 1024 * 1024);
 
-      using _exposer = expose(a, handlers);
-      const api = await wrap<typeof handlers>(b);
+        assertEquals(value![0], 0);
+        assertEquals(value![1023], 1023 % 256);
+        assertEquals(value![1024 * 1024 - 1], (1024 * 1024 - 1) % 256);
 
-      const result = await api("getStream", []);
-      const reader = (result as ReadableStream<Uint8Array>).getReader();
+        const { done: done2 } = await reader.read();
+        assertEquals(done2, true);
+        reader.releaseLock();
+      },
+    );
 
-      const { done } = await reader.read();
-      assertEquals(done, true);
-      reader.releaseLock();
-    },
-  );
+    await t.step(
+      "returns transferable MessagePort from handler",
+      async () => {
+        using pair = memoryPair();
+        const { port1: a, port2: b } = pair;
 
-  await t.step(
-    "returns transferable ReadableStream - large data",
-    async () => {
-      using pair = memoryPair();
-      const { port1: a, port2: b } = pair;
-      const handlers = {
-        getStream() {
-          const data = new Uint8Array(1024 * 1024); // 1MB
-          for (let i = 0; i < data.length; i++) {
-            data[i] = i % 256;
-          }
-          const stream = new ReadableStream({
-            start(controller) {
-              controller.enqueue(data);
-              controller.close();
-            },
-          });
-          return transferables(stream, [stream]);
-        },
-      };
-
-      using _exposer = expose(a, handlers);
-      const api = await wrap<typeof handlers>(b);
-
-      const result = await api("getStream", []);
-      const reader = (result as ReadableStream<Uint8Array>).getReader();
-
-      const { value, done } = await reader.read();
-      assertEquals(done, false);
-      assertEquals(value!.length, 1024 * 1024);
-
-      assertEquals(value![0], 0);
-      assertEquals(value![1023], 1023 % 256);
-      assertEquals(value![1024 * 1024 - 1], (1024 * 1024 - 1) % 256);
-
-      const { done: done2 } = await reader.read();
-      assertEquals(done2, true);
-      reader.releaseLock();
-    },
-  );
-
-  await t.step(
-    "returns transferable MessagePort from handler",
-    async () => {
-      using pair = memoryPair();
-      const { port1: a, port2: b } = pair;
-
-      // Create MessageChannel in test scope so we can clean up port2
-      const mc = new MessageChannel();
-      mc.port2.addEventListener("message", (ev) => {
-        mc.port2.postMessage(`echo: ${ev.data}`);
-      });
-      mc.port2.start();
-
-      const handlers = {
-        getPort() {
-          return transferables(mc.port1, [mc.port1]);
-        },
-      };
-
-      using _exposer = expose(a, handlers);
-      const api = await wrap<typeof handlers>(b);
-
-      const result = await api("getPort", []);
-      assertEquals(result instanceof MessagePort, true);
-
-      // Verify the port is actually usable after transfer
-      const port = result as MessagePort;
-      port.start();
-
-      const messagePromise = new Promise<string>((resolve) => {
-        port.addEventListener("message", (ev) => {
-          resolve(ev.data as string);
+        // Create MessageChannel in test scope so we can clean up port2
+        const mc = new MessageChannel();
+        mc.port2.addEventListener("message", (ev) => {
+          mc.port2.postMessage(`echo: ${ev.data}`);
         });
-      });
+        mc.port2.start();
 
-      port.postMessage("hello from transferred port");
-      const received = await messagePromise;
-      assertEquals(received, "echo: hello from transferred port");
+        const handlers = {
+          getPort() {
+            return transferables(mc.port1, [mc.port1]);
+          },
+        };
 
-      // Cleanup transferred port and the original channel's port2
-      port.close();
-      mc.port2.close();
-    },
-  );
+        using _exposer = expose(a, handlers);
+        const api = await wrap<typeof handlers>(b);
+
+        const result = await api("getPort", []);
+        assertEquals(result instanceof MessagePort, true);
+
+        // Verify the port is actually usable after transfer
+        const port = result as MessagePort;
+        port.start();
+
+        const messagePromise = new Promise<string>((resolve) => {
+          port.addEventListener("message", (ev) => {
+            resolve(ev.data as string);
+          });
+        });
+
+        port.postMessage("hello from transferred port");
+        const received = await messagePromise;
+        assertEquals(received, "echo: hello from transferred port");
+
+        // Cleanup transferred port and the original channel's port2
+        port.close();
+        mc.port2.close();
+      },
+    );
   },
 });

--- a/mod.ts
+++ b/mod.ts
@@ -2,3 +2,4 @@ export type * from "./types.ts";
 export type * from "./shared_types.ts";
 export * from "./expose.ts";
 export * from "./wrap.ts";
+export { kTransferables, transferables } from "./types.ts";

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -792,7 +792,7 @@ Deno.test("RPC wrap with transfer option", async () => {
 
 Deno.test("RPC expose uses default onMessageError handler", () => {
   using pair = memoryPair();
-  const { port1: a, port2: b } = pair;
+  const { port1: a } = pair;
   const handlers = {
     test() {
       return "works";
@@ -825,7 +825,7 @@ Deno.test("RPC expose uses default onMessageError handler", () => {
 
 Deno.test("RPC expose uses custom onMessageError handler", () => {
   using pair = memoryPair();
-  const { port1: a, port2: b } = pair;
+  const { port1: a } = pair;
   const handlers = {
     test() {
       return "works";
@@ -900,7 +900,7 @@ Deno.test("RPC wrap ignores cancel postMessage errors", async () => {
   const originalPostMessage = b.postMessage.bind(b);
   // deno-lint-ignore no-explicit-any
   (b as any).postMessage = function (
-    message: any,
+    message: { kind?: string },
     transfer?: Transferable[],
   ) {
     if (message.kind === "cancel") {

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -233,13 +233,13 @@ Deno.test("RPC expose handles malformed data", async () => {
   };
   using _disposable = expose(a, handlers);
 
-  // Send malformed data
-  a.postMessage(null, []);
-  a.postMessage(undefined, []);
-  a.postMessage({}, []);
-  a.postMessage({ kind: "unknown" }, []);
-  a.postMessage({ kind: "call" }, []); // missing id/name
-  a.postMessage({ kind: "call", id: "test-id" }, []); // missing name
+  // Send malformed data on b so it reaches a where expose listens
+  b.postMessage(null, []);
+  b.postMessage(undefined, []);
+  b.postMessage({}, []);
+  b.postMessage({ kind: "unknown" }, []);
+  b.postMessage({ kind: "call" }, []); // missing id/name
+  b.postMessage({ kind: "call", id: "test-id" }, []); // missing name
 
   // Regular call should still work
   const api = await wrap<typeof handlers>(b);
@@ -282,18 +282,18 @@ Deno.test("RPC expose handles legacy cancel message format", async () => {
   };
   using _disposable = expose(a, handlers);
 
-  // Send a legacy cancel message with just 'id' (no idRef)
-  a.postMessage({ id: "some-call-id", kind: "cancel" }, []);
+  // Send a legacy cancel message with just 'id' (no idRef) on b so it reaches a
+  b.postMessage({ id: "some-call-id", kind: "cancel" }, []);
 
-  // Send a cancel message with idRef as well
-  a.postMessage({
+  // Send a cancel message with idRef as well on b so it reaches a
+  b.postMessage({
     id: "cancel-msg-id",
     kind: "cancel",
     idRef: "some-other-call-id",
   }, []);
 
-  // Send a cancel with no id at all
-  a.postMessage({ kind: "cancel" }, []);
+  // Send a cancel with no id at all on b so it reaches a
+  b.postMessage({ kind: "cancel" }, []);
 
   // Regular call should still work
   const api = await wrap<typeof handlers>(b);
@@ -336,12 +336,12 @@ Deno.test("RPC wrap handles malformed response messages", async () => {
   using _disposable = expose(a, handlers);
   const api = await wrap<typeof handlers>(b);
 
-  // Send malformed response messages
-  b.postMessage(null, []);
-  b.postMessage({}, []);
-  b.postMessage({ kind: "unknown" }, []);
-  b.postMessage({ kind: "result" }, []); // missing id
-  b.postMessage({ kind: "result", id: "nonexistent" }, []); // unknown id
+  // Send malformed response messages on a so they reach b where wrap listens
+  a.postMessage(null, []);
+  a.postMessage({}, []);
+  a.postMessage({ kind: "unknown" }, []);
+  a.postMessage({ kind: "result" }, []); // missing id
+  a.postMessage({ kind: "result", id: "nonexistent" }, []); // unknown id
 
   // Regular call should still work
   assertEquals(await api("test", []), "works");
@@ -508,9 +508,9 @@ Deno.test("RPC expose cancel with missing callId", async () => {
   };
   using _disposable = expose(a, handlers);
 
-  // Send cancel message with no callId/idRef - should be handled gracefully
-  a.postMessage({ kind: "cancel", id: "cancel-msg-id" }, []); // No idRef
-  a.postMessage({ kind: "cancel" }, []); // No id or idRef
+  // Send cancel message with no callId/idRef on b so it reaches a
+  b.postMessage({ kind: "cancel", id: "cancel-msg-id" }, []); // No idRef
+  b.postMessage({ kind: "cancel" }, []); // No id or idRef
 
   const api = await wrap<typeof handlers>(b);
   assertEquals(await api("test", []), "works");
@@ -786,6 +786,140 @@ Deno.test("RPC wrap with transfer option", async () => {
 
   // Buffer should be neutered (transferred)
   assertEquals(buffer.byteLength, 0);
+
+  api[Symbol.dispose]();
+});
+
+Deno.test("RPC expose uses default onMessageError handler", () => {
+  using pair = memoryPair();
+  const { port1: a, port2: b } = pair;
+  const handlers = {
+    test() {
+      return "works";
+    },
+  };
+
+  // Spy on console.error
+  const originalConsoleError = console.error;
+  let consoleErrorCalled = false;
+  // deno-lint-ignore no-explicit-any
+  console.error = (..._args: any[]) => {
+    consoleErrorCalled = true;
+  };
+
+  try {
+    // Expose without custom onMessageError - should use default handler
+    using _disposable = expose(a, handlers);
+
+    // Dispatch synthetic messageerror on a where expose listens
+    // deno-lint-ignore no-explicit-any
+    (a as any).dispatchEvent(
+      new MessageEvent("messageerror", { data: "test error" }),
+    );
+
+    assertEquals(consoleErrorCalled, true);
+  } finally {
+    console.error = originalConsoleError;
+  }
+});
+
+Deno.test("RPC expose uses custom onMessageError handler", () => {
+  using pair = memoryPair();
+  const { port1: a, port2: b } = pair;
+  const handlers = {
+    test() {
+      return "works";
+    },
+  };
+
+  let customHandlerCalled = false;
+
+  // Expose with custom onMessageError
+  using _disposable = expose(a, handlers, {
+    onMessageError: (_ev: MessageEvent) => {
+      customHandlerCalled = true;
+    },
+  });
+
+  // Dispatch synthetic messageerror on a where expose listens
+  // deno-lint-ignore no-explicit-any
+  (a as any).dispatchEvent(
+    new MessageEvent("messageerror", { data: "test error" }),
+  );
+
+  assertEquals(customHandlerCalled, true);
+});
+
+Deno.test("RPC wrap uses default onMessageError handler", async () => {
+  using pair = memoryPair();
+  const { port1: a, port2: b } = pair;
+  const handlers = {
+    test() {
+      return "works";
+    },
+  };
+
+  // Spy on console.error
+  const originalConsoleError = console.error;
+  let consoleErrorCalled = false;
+  // deno-lint-ignore no-explicit-any
+  console.error = (..._args: any[]) => {
+    consoleErrorCalled = true;
+  };
+
+  try {
+    using _disposable = expose(a, handlers);
+    // Wrap without custom onMessageError - should use default handler
+    const api = await wrap<typeof handlers>(b);
+
+    // Dispatch synthetic messageerror on b where wrap listens
+    // deno-lint-ignore no-explicit-any
+    (b as any).dispatchEvent(
+      new MessageEvent("messageerror", { data: "test error" }),
+    );
+
+    assertEquals(consoleErrorCalled, true);
+    api[Symbol.dispose]();
+  } finally {
+    console.error = originalConsoleError;
+  }
+});
+
+Deno.test("RPC wrap ignores cancel postMessage errors", async () => {
+  using pair = memoryPair();
+  const { port1: a, port2: b } = pair;
+  const handlers = {
+    longTask(_ms: number, _signal?: AbortSignal): Promise<string> {
+      return new Promise(() => {}); // Never resolves
+    },
+  };
+
+  using _disposable = expose(a, handlers);
+
+  // Monkey-patch b.postMessage to throw for cancel messages
+  const originalPostMessage = b.postMessage.bind(b);
+  // deno-lint-ignore no-explicit-any
+  (b as any).postMessage = function (
+    message: any,
+    transfer?: Transferable[],
+  ) {
+    if (message.kind === "cancel") {
+      throw new Error("cancel post failed");
+    }
+    return originalPostMessage(message, transfer);
+  };
+
+  const api = await wrap<typeof handlers>(b);
+
+  const callPromise = api("longTask", [100], {
+    signal: AbortSignal.timeout(10),
+  });
+
+  await assertRejects(
+    () => callPromise,
+    Error,
+    "aborted",
+  );
 
   api[Symbol.dispose]();
 });

--- a/signal_ready.ts
+++ b/signal_ready.ts
@@ -3,5 +3,6 @@ import type { Endpoint } from "./shared_types.ts";
 
 /** Signal that this endpoint is ready to receive messages. */
 
-export const signalReady = (endpoint: Endpoint) =>
+export const signalReady = (endpoint: Endpoint): void => {
   endpoint.postMessage({ kind: "ready" } as ReadyMsg, []);
+};

--- a/signal_ready_test.ts
+++ b/signal_ready_test.ts
@@ -1,5 +1,4 @@
 import { assertEquals } from "@std/assert/equals";
-import { delay } from "@std/async/delay";
 import { signalReady } from "./signal_ready.ts";
 import { memoryPair } from "./test_utils.ts";
 
@@ -7,20 +6,24 @@ Deno.test("signalReady()", async () => {
   using pair = memoryPair();
   const { port1: a, port2: b } = pair;
 
-  // deno-lint-ignore no-explicit-any
-  let receivedMessage: any;
+  let resolveReceivedMessage:
+    | ((value: { kind?: string } | undefined) => void)
+    | undefined;
+  const receivedMessagePromise = new Promise<{ kind?: string } | undefined>(
+    (resolve) => {
+      resolveReceivedMessage = resolve;
+    },
+  );
   const cleanup = (() => {
     const controller = new AbortController();
     // deno-lint-ignore no-explicit-any
-    const handler = (ev: any) => receivedMessage = ev.data;
+    const handler = (ev: any) => resolveReceivedMessage?.(ev.data);
     b.addEventListener("message", handler, { signal: controller.signal });
     return controller.abort.bind(controller);
   })();
 
   signalReady(a);
-
-  // Give it time to arrive
-  await delay(10);
+  const receivedMessage = await receivedMessagePromise;
 
   assertEquals(receivedMessage?.kind, "ready");
 

--- a/types.ts
+++ b/types.ts
@@ -36,6 +36,23 @@ export interface ExposeOptions {
   onMessageError?: (ev: MessageEvent) => void;
 }
 
+/** Symbol to mark transferable objects on return values */
+export const kTransferables = Symbol.for("endpoint-link.transferables");
+
+/**
+ * Mark a return value with transferable objects.
+ * The value itself is returned unchanged, but the transfer list is
+ * attached via a non-enumerable Symbol property.
+ */
+export function transferables<T>(value: T, list: Transferable[]): T {
+  Reflect.defineProperty(value, kTransferables, {
+    value: list,
+    enumerable: false,
+    writable: false,
+  });
+  return value;
+}
+
 /** Remote return type - always wrapped in Promise */
 export type RemoteReturnType<T> = Promise<Awaited<T>>;
 

--- a/types.ts
+++ b/types.ts
@@ -37,14 +37,19 @@ export interface ExposeOptions {
 }
 
 /** Symbol to mark transferable objects on return values */
-export const kTransferables = Symbol.for("endpoint-link.transferables");
+export const kTransferables: unique symbol = Symbol.for(
+  "endpoint-link.transferables",
+);
 
 /**
  * Mark a return value with transferable objects.
  * The value itself is returned unchanged, but the transfer list is
  * attached via a non-enumerable Symbol property.
  */
-export function transferables<T>(value: T, list: Transferable[]): T {
+export function transferables<T extends object>(
+  value: T,
+  list: Transferable[],
+): T {
   Reflect.defineProperty(value, kTransferables, {
     value: list,
     enumerable: false,


### PR DESCRIPTION
This PR adds support for transferable objects on the `expose` side, along with related fixes and improvements:

- **feat**: Add `transferables` helper for expose-side transfer support
- **test**: Fix port-swapped tests and achieve 100% coverage
- **fix**: Resolve type-check and lint errors
- **chore**: Update Deno dependencies

## Summary

The main feature introduces a `transferables` helper that allows handlers registered via `expose()` to specify which objects should be transferred (not just cloned) when sending responses back to the caller.

This enables efficient passing of `ArrayBuffer`, `MessagePort`, and other [Transferable](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Transferable_objects) objects without copying.

### Usage

```ts
import { expose, transferables } from "@takker/endpoint-link";

expose(endpoint, {
  getBuffer: () => {
    const buffer = new ArrayBuffer(1024);
    return transferables({ result: buffer, transfer: [buffer] });
  },
});
```

All existing tests pass with 100% coverage.